### PR TITLE
feat(fullscreen) INT-4249: iPadOS fullscreen on non-video elements

### DIFF
--- a/libs/ngx-videogular/core/src/lib/services/vg-fullscreen-api/vg-fullscreen-api.service.ts
+++ b/libs/ngx-videogular/core/src/lib/services/vg-fullscreen-api/vg-fullscreen-api.service.ts
@@ -83,7 +83,7 @@ export class VgFullscreenApiService {
       }
     }
 
-    if (VgUtilsService.isiOSDevice()) {
+    if (VgUtilsService.isiOSDevice() && !VgUtilsService.isIpadOS()) {
       this.polyfill = APIs.ios;
     }
 

--- a/libs/ngx-videogular/core/src/lib/services/vg-fullscreen-api/vg-fullscreen-api.service.ts
+++ b/libs/ngx-videogular/core/src/lib/services/vg-fullscreen-api/vg-fullscreen-api.service.ts
@@ -141,7 +141,7 @@ export class VgFullscreenApiService {
     // Perform native full screen support
     if (this.isAvailable && this.nativeFullscreen) {
       // Fullscreen for mobile devices
-      if (VgUtilsService.isMobileDevice()) {
+      if (VgUtilsService.isMobileDevice() && !VgUtilsService.isIpadOS()) {
         // We should make fullscreen the video object if it doesn't have native fullscreen support
         // Fallback! We can't set vg-player on fullscreen, only video/audio objects
         if (

--- a/libs/ngx-videogular/package.json
+++ b/libs/ngx-videogular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@49ing/ngx-videogular",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "The HTML5 video player for Angular 2 and successor to videogular2",
   "license": "MIT",
   "publishConfig": {

--- a/libs/ngx-videogular/package.json
+++ b/libs/ngx-videogular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@49ing/ngx-videogular",
-  "version": "5.0.9",
+  "version": "5.2.0",
   "description": "The HTML5 video player for Angular 2 and successor to videogular2",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@49ing/ngx-videogular",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "license": "MIT",
   "description": "The HTML5 video player for Angular 2 and successor to videogular2",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@49ing/ngx-videogular",
-  "version": "5.0.9",
+  "version": "5.2.0",
   "license": "MIT",
   "description": "The HTML5 video player for Angular 2 and successor to videogular2",
   "publishConfig": {


### PR DESCRIPTION
### Description
On iPad devices it's preferable to have the full videogular element visible in fullscreen instead of the pure video element only. This allows users to see custom components, such a video overlays in fullscreen.

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/ngx-videogular/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)